### PR TITLE
Allow painterro to be used in a placeholder element within a form

### DIFF
--- a/js/colorPicker.js
+++ b/js/colorPicker.js
@@ -288,11 +288,11 @@ export default class ColorPicker {
           '<span class="ptro-color-alpha-regulator ptro-bordered-control"></span>' +
           '<div class="ptro-colors"></div>' +
           '<div class="ptro-color-edit">' +
-            '<button class="ptro-icon-btn ptro-pipette ptro-color-control" style="float: left; margin-right: 5px">' +
+            '<button type="button" class="ptro-icon-btn ptro-pipette ptro-color-control" style="float: left; margin-right: 5px">' +
               '<i class="ptro-icon ptro-icon-pipette"></i>' +
             '</button>' +
             '<input class="ptro-input ptro-color" type="text" size="7"/>' +
-            '<button class="ptro-named-btn ptro-close-color-picker ptro-color-control" >' +
+            '<button type="button" class="ptro-named-btn ptro-close-color-picker ptro-color-control" >' +
             `${tr('close')}</button>` +
           '</div>' +
         '</div>' +

--- a/js/inserter.js
+++ b/js/inserter.js
@@ -197,7 +197,7 @@ export default class Inserter {
     Object.keys(this.pasteOptions).forEach((k) => {
       const o = this.pasteOptions[k];
       o.id = genId();
-      buttons += `<button id="${o.id}" class="ptro-selector-btn ptro-color-control">` +
+      buttons += `<button type="button" id="${o.id}" class="ptro-selector-btn ptro-color-control">` +
         `<div><i class="ptro-icon ptro-icon-paste_${k}"></i></div>` +
         `<div>${tr(`pasteOptions.${k}`)}</div>` +
       '</button>';

--- a/js/main.js
+++ b/js/main.js
@@ -424,7 +424,7 @@ class PainterroProc {
     this.tools.filter(t => this.params.hiddenTools.indexOf(t.name) === -1).forEach((b) => {
       const id = genId();
       b.buttonId = id;
-      const btn = `<button class="ptro-icon-btn ptro-color-control" title="${tr(`tools.${b.name}`)}" ` +
+      const btn = `<button type="button" class="ptro-icon-btn ptro-color-control" title="${tr(`tools.${b.name}`)}" ` +
         `id="${id}" >` +
         `<i class="ptro-icon ptro-icon-${b.name}"></i></button>`;
       if (b.right) {
@@ -1078,11 +1078,11 @@ class PainterroProc {
         ctrls += `<span class="ptro-tool-ctl-name" title="${tr(ctl.titleFull)}">${tr(ctl.title)}</span>`;
       }
       if (ctl.type === 'btn') {
-        ctrls += `<button ${ctl.hint ? `title="${tr(ctl.hint)}"` : ''} class="ptro-color-control ${ctl.icon ? 'ptro-icon-btn' : 'ptro-named-btn'}" ` +
+        ctrls += `<button type="button" ${ctl.hint ? `title="${tr(ctl.hint)}"` : ''} class="ptro-color-control ${ctl.icon ? 'ptro-icon-btn' : 'ptro-named-btn'}" ` +
           `id=${ctl.id}>${ctl.icon ? `<i class="ptro-icon ptro-icon-${ctl.icon}"></i>` : ''}` +
           `<p>${ctl.name || ''}</p></button>`;
       } else if (ctl.type === 'color') {
-        ctrls += `<button id=${ctl.id} data-id='${ctl.target}' ` +
+        ctrls += `<button type="button" id=${ctl.id} data-id='${ctl.target}' ` +
           `style="background-color: ${this.colorWidgetState[ctl.target].alphaColor}" ` +
           'class="color-diwget-btn ptro-color-btn ptro-bordered-btn"></button>' +
           '<span class="ptro-btn-color-checkers-bar"></span>';

--- a/js/main.js
+++ b/js/main.js
@@ -690,9 +690,9 @@ class PainterroProc {
       mousedown: (e) => {
         if (this.shown) {
           if (this.worklog.empty &&
-             (e.target.className.includes('ptro-crp-el') ||
-              e.target.className.includes('ptro-icon') ||
-              e.target.className.includes('ptro-named-btn'))) {
+             (e.target.className.indexOf('ptro-crp-el') !== -1 ||
+              e.target.className.indexOf('ptro-icon') !== -1 ||
+              e.target.className.indexOf('ptro-named-btn') !== -1)) {
             this.clearBackground(); // clear initText
           }
           if (this.colorPicker.handleMouseDown(e) !== true) {

--- a/js/resizer.js
+++ b/js/resizer.js
@@ -127,17 +127,17 @@ export default class Resizer {
             '</table>' +
           '</div>' +
           '<div class="ptro-resize-link-wrapper">' +
-            `<button class="ptro-icon-btn ptro-link ptro-color-control" title="${tr('keepRatio')}">` +
+            `<button type="button" class="ptro-icon-btn ptro-link ptro-color-control" title="${tr('keepRatio')}">` +
               '<i class="ptro-icon ptro-icon-linked" style="font-size: 18px;"></i>' +
             '</button>' +
           '</div>' +
           '<div></div>' +
           '<div style="margin-top: 40px;">' +
-            '<button class="ptro-named-btn ptro-resize ptro-color-control">' +
+            '<button type="button" class="ptro-named-btn ptro-resize ptro-color-control">' +
                   `${tr('resizeResize')}</button>` +
-            '<button class="ptro-named-btn ptro-scale ptro-color-control">' +
+            '<button type="button" class="ptro-named-btn ptro-scale ptro-color-control">' +
                   `${tr('resizeScale')}</button>` +
-            '<button class="ptro-named-btn ptro-close ptro-color-control">' +
+            '<button type="button" class="ptro-named-btn ptro-close ptro-color-control">' +
                   `${tr('cancel')}</button>` +
           '</div>' +
         '</div>' +

--- a/js/settings.js
+++ b/js/settings.js
@@ -85,12 +85,12 @@ export default class Settings {
               '<tr>' +
                 `<td class="ptro-label ptro-resize-table-left" style="height:30px;">${tr('backgroundColor')}</td>` +
                 '<td class="ptro-strict-cell">' +
-                  '<button data-id="bg" class="ptro-color-btn ptro-bordered-btn" ' +
+                  '<button type="button" data-id="bg" class="ptro-color-btn ptro-bordered-btn" ' +
                     'style="margin-top: -12px;"></button>' +
                   '<span class="ptro-btn-color-checkers"></span>' +
                 '</td>' +
                 '<td>' +
-                  `<button style="margin-top: -2px;" class="ptro-named-btn ptro-clear ptro-color-control" title="${tr('fillPageWith')}">${tr('clear')}</button>` +
+                  `<button type="button" style="margin-top: -2px;" class="ptro-named-btn ptro-clear ptro-color-control" title="${tr('fillPageWith')}">${tr('clear')}</button>` +
                 '</td>' +
               '</tr>' +
               '<tr>' +
@@ -102,9 +102,9 @@ export default class Settings {
             '</table>' +
             '<div class="ptro-error" hidden></div>' +
             '<div style="margin-top: 20px">' +
-              '<button class="ptro-named-btn ptro-apply ptro-color-control">' +
+              '<button type="button" class="ptro-named-btn ptro-apply ptro-color-control">' +
                     `${tr('apply')}</button>` +
-              `<button class="ptro-named-btn ptro-close ptro-color-control">${tr('cancel')}</button>` +
+              `<button type="button" class="ptro-named-btn ptro-close ptro-color-control">${tr('cancel')}</button>` +
             '</div>' +
         '</div>' +
       '</div>';

--- a/js/text.js
+++ b/js/text.js
@@ -244,11 +244,11 @@ export default class TextTool {
     return '<span class="ptro-text-tool-input-wrapper">' +
       '<div contenteditable="true" class="ptro-text-tool-input"></div>' +
         '<span class="ptro-text-tool-buttons">' +
-          `<button class="ptro-text-tool-apply ptro-icon-btn ptro-color-control" title="${tr('apply')}" 
+          `<button type="button" class="ptro-text-tool-apply ptro-icon-btn ptro-color-control" title="${tr('apply')}" 
                    style="margin: 2px">` +
             '<i class="ptro-icon ptro-icon-apply"></i>' +
           '</button>' +
-          `<button class="ptro-text-tool-cancel ptro-icon-btn ptro-color-control" title="${tr('cancel')}"
+          `<button type="button" class="ptro-text-tool-cancel ptro-icon-btn ptro-color-control" title="${tr('cancel')}"
                    style="margin: 2px">` +
             '<i class="ptro-icon ptro-icon-close"></i>' +
           '</button>' +


### PR DESCRIPTION
I found that when using the Painterro widget in a container div, which happened to be within a form, I could not use any of the buttons as they all caused a form submission and the page to reload.  This is because the type parameter is not specified on the buttons so it defaults to submit.  Setting type="button" fixes the issue, so I thought you might find this change useful?

Great work by the way!
Thanks
Dave