### PR TITLE
Customise toolbar position and allow drop downs for line width, font size and eraser widths

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,10 @@ Painterro({
 |`initTextStyle` | Style of init text | "26px 'Open Sans', sans-serif" |
 |`pixelizePixelSize` | Default pixel size of pixelize tool. Can accept values - `x` - x pixels, `x%` - means percents of minimal area rectangle side | `20%` |
 |`changeHandler` | Function that will be called if something will be changed (painted, erased, resized, etc) | undefined |
-
+|`availableLineWidths` | A list of the line width values that are available for selection in a drop down list e.g. `[1,2,4,8,16,64]`.  Otherwise an input field is used. | undefined |
+|`availableEraserWidths` | A list of the eraser width values that are available for selection in a drop down list e.g. `[1,2,4,8,16,64]`.  Otherwise an input field is used. | undefined |
+|`availableFontSizes` | A list of the font size values that are available for selection in a drop down list e.g. `[1,2,4,8,16,64]`.  Otherwise an input field is used. | undefined |
+|`toolbarPosition` | Whether to position the toolbar at the top or bottom. | 'bottom' |
 
 UI color scheme
 ---------------

--- a/js/controlbuilder.js
+++ b/js/controlbuilder.js
@@ -1,0 +1,77 @@
+import { setParam } from './params';
+
+export default class ControlBuilder {
+  constructor(main) {
+    this.main = main;
+  }
+
+  buildFontSizeControl(controlIndex) {
+    const action = () => {
+      const fontSize =
+        document.getElementById(this.main.activeTool.controls[controlIndex].id).value;
+      this.main.textTool.setFontSize(fontSize);
+      setParam('defaultFontSize', fontSize);
+    };
+    const getValue = () => this.main.textTool.fontSize;
+
+    if (this.main.params.availableFontSizes) {
+      return ControlBuilder.buildDropDownControl('fontSize', action, getValue, this.main.params.availableFontSizes);
+    }
+    return ControlBuilder.buildInputControl('fontSize', action, getValue, 1, 200);
+  }
+
+  buildEraserWidthControl(controlIndex) {
+    const action = () => {
+      const width = document.getElementById(this.main.activeTool.controls[controlIndex].id).value;
+      this.main.primitiveTool.setEraserWidth(width);
+      setParam('defaultEraserWidth', width);
+    };
+    const getValue = () => this.main.primitiveTool.eraserWidth;
+
+    if (this.main.params.availableEraserWidths) {
+      return ControlBuilder.buildDropDownControl('eraserWidth', action, getValue, this.main.params.availableEraserWidths);
+    }
+    return ControlBuilder.buildInputControl('eraserWidth', action, getValue, 1, 99);
+  }
+
+  buildLineWidthControl(controlIndex) {
+    const action = () => {
+      const width = document.getElementById(this.main.activeTool.controls[controlIndex].id).value;
+      this.main.primitiveTool.setLineWidth(width);
+      setParam('defaultLineWidth', width);
+    };
+    const getValue = () => this.main.primitiveTool.lineWidth;
+
+    if (this.main.params.availableLineWidths) {
+      return ControlBuilder.buildDropDownControl('lineWidth', action, getValue, this.main.params.availableLineWidths);
+    }
+    return ControlBuilder.buildInputControl('lineWidth', action, getValue, 1, 99);
+  }
+
+  static buildInputControl(name, action, getValue, minVal, maxVal) {
+    return {
+      type: 'int',
+      title: name,
+      titleFull: `${name}Full`,
+      target: name,
+      min: minVal,
+      max: maxVal,
+      action,
+      getValue,
+    };
+  }
+
+  static buildDropDownControl(name, action, getValue, availableValues) {
+    return {
+      type: 'dropdown',
+      title: name,
+      titleFull: `${name}Full`,
+      target: name,
+      action,
+      getValue,
+      getAvailableValues: () => availableValues.map(
+        x => ({ value: x, name: x.toString(), title: x.toString() })),
+    };
+  }
+}
+

--- a/js/main.js
+++ b/js/main.js
@@ -17,11 +17,13 @@ import TextTool from './text';
 import Resizer from './resizer';
 import Inserter from './inserter';
 import Settings from './settings';
+import ControlBuilder from './controlbuilder';
 
 class PainterroProc {
   constructor(params) {
     addDocumentObjectHelpers();
     this.params = setDefaults(params);
+    this.controlBuilder = new ControlBuilder(this);
 
     this.colorWidgetState = {
       line: {
@@ -86,20 +88,8 @@ class PainterroProc {
         action: () => {
           this.colorPicker.open(this.colorWidgetState.line);
         },
-      }, {
-        type: 'int',
-        title: 'lineWidth',
-        titleFull: 'lineWidthFull',
-        target: 'lineWidth',
-        min: 1,
-        max: 99,
-        action: () => {
-          const width = document.getElementById(this.activeTool.controls[1].id);
-          this.primitiveTool.setLineWidth(width.value);
-          setParam('defaultLineWidth', width.value);
-        },
-        getValue: () => this.primitiveTool.lineWidth,
-      }],
+      }, this.controlBuilder.buildLineWidthControl(1),
+      ],
       activate: () => {
         this.toolContainer.style.cursor = 'crosshair';
         this.primitiveTool.activate('line');
@@ -123,20 +113,7 @@ class PainterroProc {
         action: () => {
           this.colorPicker.open(this.colorWidgetState.fill);
         },
-      }, {
-        type: 'int',
-        title: 'lineWidth',
-        titleFull: 'lineWidthFull',
-        target: 'lineWidth',
-        min: 1,
-        max: 99,
-        action: () => {
-          const width = document.getElementById(this.activeTool.controls[2].id).value;
-          this.primitiveTool.setLineWidth(width);
-          setParam('defaultLineWidth', width.value);
-        },
-        getValue: () => this.primitiveTool.lineWidth,
-      },
+      }, this.controlBuilder.buildLineWidthControl(2),
       ],
       activate: () => {
         this.toolContainer.style.cursor = 'crosshair';
@@ -161,20 +138,7 @@ class PainterroProc {
         action: () => {
           this.colorPicker.open(this.colorWidgetState.fill);
         },
-      }, {
-        type: 'int',
-        title: 'lineWidth',
-        titleFull: 'lineWidthFull',
-        target: 'lineWidth',
-        min: 1,
-        max: 99,
-        action: () => {
-          const width = document.getElementById(this.activeTool.controls[2].id).value;
-          this.primitiveTool.setLineWidth(width);
-          setParam('defaultLineWidth', width.value);
-        },
-        getValue: () => this.primitiveTool.lineWidth,
-      },
+      }, this.controlBuilder.buildLineWidthControl(2),
       ],
       activate: () => {
         this.toolContainer.style.cursor = 'crosshair';
@@ -191,20 +155,7 @@ class PainterroProc {
         action: () => {
           this.colorPicker.open(this.colorWidgetState.line);
         },
-      }, {
-        type: 'int',
-        title: 'lineWidth',
-        titleFull: 'lineWidthFull',
-        target: 'lineWidth',
-        min: 1,
-        max: 99,
-        action: () => {
-          const width = document.getElementById(this.activeTool.controls[1].id);
-          this.primitiveTool.setLineWidth(width.value);
-          setParam('defaultLineWidth', width.value);
-        },
-        getValue: () => this.primitiveTool.lineWidth,
-      },
+      }, this.controlBuilder.buildLineWidthControl(1),
       ],
       activate: () => {
         this.toolContainer.style.cursor = 'crosshair';
@@ -213,20 +164,7 @@ class PainterroProc {
       eventListner: () => this.primitiveTool,
     }, {
       name: 'eraser',
-      controls: [{
-        type: 'int',
-        title: 'eraserWidth',
-        titleFull: 'eraserWidthFull',
-        target: 'eraserWidth',
-        min: 1,
-        max: 99,
-        action: () => {
-          const width = document.getElementById(this.activeTool.controls[0].id);
-          this.primitiveTool.setEraserWidth(width.value);
-          setParam('defaultEraserWidth', width.value);
-        },
-        getValue: () => this.primitiveTool.eraserWidth,
-      },
+      controls: [this.controlBuilder.buildEraserWidthControl(0),
       ],
       activate: () => {
         this.toolContainer.style.cursor = 'crosshair';
@@ -246,20 +184,8 @@ class PainterroProc {
               this.textTool.setFontColor(c.alphaColor);
             });
           },
-        }, {
-          type: 'int',
-          title: 'fontSize',
-          titleFull: 'fontSizeFull',
-          target: 'fontSize',
-          min: 1,
-          max: 200,
-          action: () => {
-            const width = document.getElementById(this.activeTool.controls[1].id).value;
-            this.textTool.setFontSize(width);
-            setParam('defaultFontSize', width);
-          },
-          getValue: () => this.textTool.fontSize,
-        }, {
+        }, this.controlBuilder.buildFontSizeControl(1),
+        {
           type: 'dropdown',
           title: 'fontName',
           titleFull: 'fontNameFull',
@@ -270,7 +196,7 @@ class PainterroProc {
             this.textTool.setFont(font);
           },
           getValue: () => this.textTool.getFont(),
-          getAvilableValues: () => TextTool.getFonts(),
+          getAvailableValues: () => TextTool.getFonts(),
         }, {
           type: 'dropdown',
           title: 'fontStyle',
@@ -282,7 +208,7 @@ class PainterroProc {
             this.textTool.setFontStyle(style);
           },
           getValue: () => this.textTool.getFontStyle(),
-          getAvilableValues: () => TextTool.getFontStyles(),
+          getAvailableValues: () => TextTool.getFontStyles(),
         },
         // {
         //   type: 'int',
@@ -1091,7 +1017,7 @@ class PainterroProc {
           `data-id='${ctl.target}'/>`;
       } else if (ctl.type === 'dropdown') {
         let options = '';
-        ctl.getAvilableValues().forEach((o) => {
+        ctl.getAvailableValues().forEach((o) => {
           options += `<option ${o.extraStyle ? `style='${o.extraStyle}'` : ''}` +
             ` value='${o.value}' ${o.title ? `title='${o.title}'` : ''}>${o.name}</option>`;
         });
@@ -1106,6 +1032,7 @@ class PainterroProc {
         this.doc.getElementById(ctl.id).oninput = ctl.action;
       } else if (ctl.type === 'dropdown') {
         this.doc.getElementById(ctl.id).onchange = ctl.action;
+        this.doc.getElementById(ctl.id).value = ctl.getValue();
       } else {
         this.doc.getElementById(ctl.id).onclick = ctl.action;
       }

--- a/js/main.js
+++ b/js/main.js
@@ -690,9 +690,9 @@ class PainterroProc {
       mousedown: (e) => {
         if (this.shown) {
           if (this.worklog.empty &&
-             (e.target.className.includes('ptro-crp-el') ||
-              e.target.className.includes('ptro-icon') ||
-              e.target.className.includes('ptro-named-btn'))) {
+             (e.target.className.indexOf('ptro-crp-el') !== -1 ||
+              e.target.className.indexOf('ptro-icon') !== -1 ||
+              e.target.className.indexOf('ptro-named-btn') !== -1)) {
             this.clearBackground(); // clear initText
           }
           if (this.colorPicker.handleMouseDown(e) !== true) {

--- a/js/params.js
+++ b/js/params.js
@@ -112,6 +112,8 @@ export function setDefaults(parameters) {
     };
   }
 
+  params.toolbarPosition = params.toolbarPosition || 'bottom';
+
   if (params.translation) {
     const name = params.translation.name;
     Translation.get().addTranslation(name, params.translation.strings);
@@ -147,7 +149,14 @@ export function setDefaults(parameters) {
     .ptro-color-active-control{
         background-color: ${params.colorScheme.activeControl};
         color:${params.colorScheme.activeControlContent}}
-    .ptro-wrapper{background-color:${params.colorScheme.backgroundColor};}}`;
+    .ptro-wrapper{
+      background-color:${params.colorScheme.backgroundColor};
+      bottom:${params.toolbarPosition === 'top' ? '0' : '40px'};
+      top:${params.toolbarPosition === 'top' ? '40px' : '0'};
+    }
+    .ptro-bar {
+      ${params.toolbarPosition === 'top' ? 'top' : 'bottom'}: 0;
+    }`;
 
   return params;
 }


### PR DESCRIPTION
I needed to add a couple of small features to Painterro which others might find useful.  First is to be able to position the toolbar at the top of the widget, so I added a config option for that.

Second, the ability to use drop down lists of values for the line width , font size, and eraser widths which is useful for users using touch screens as it is easier that having to type them in.  While doing it I moved the logic for building the controls into a separate class to avoid repeating code.

I hope this is useful!
Dave