### PR TITLE
fix issue where invalid hex colors in color picker cause it to get stuck

### DIFF
--- a/js/colorPicker.js
+++ b/js/colorPicker.js
@@ -1,7 +1,7 @@
 import { tr } from './translation';
 import { KEYS } from './utils';
 
-function HexToRGB(hex) {
+export function HexToRGB(hex) {
   let parse = /^#?([a-fA-F\d]{2})([a-fA-F\d]{2})([a-fA-F\d]{2})$/i.exec(hex);
   if (parse) {
     return {
@@ -30,7 +30,7 @@ function format2Hex(val) {
   return (hex.length === 1 && (`0${hex}`)) || hex;
 }
 
-function rgbToHex(r, g, b) {
+export function rgbToHex(r, g, b) {
   return `#${format2Hex(r)}${format2Hex(g)}${format2Hex(b)}`;
 }
 

--- a/js/main.js
+++ b/js/main.js
@@ -472,6 +472,7 @@ class PainterroProc {
       this.doc.querySelector(
         `#${this.id} .ptro-color-btn[data-id='${widgetState.target}']`).style['background-color'] =
         widgetState.alphaColor;
+      if (widgetState.palleteColor.substr(0, 1) !== '#') widgetState.palleteColor = `#${widgetState.palleteColor}`;
       if (widgetState.target === 'line') {
         setParam('activeColor', widgetState.palleteColor);
         setParam('activeColorAlpha', widgetState.alpha);

--- a/js/main.js
+++ b/js/main.js
@@ -9,7 +9,7 @@ import WorkLog from './worklog';
 import { genId, addDocumentObjectHelpers, KEYS, trim,
   getScrollbarWidth, distance } from './utils';
 import PrimitiveTool from './primitive';
-import ColorPicker from './colorPicker';
+import ColorPicker, { HexToRGB, rgbToHex } from './colorPicker';
 import { setDefaults, setParam, logError } from './params';
 import { tr } from './translation';
 import ZoomHelper from './zoomHelper';
@@ -472,19 +472,22 @@ class PainterroProc {
       this.doc.querySelector(
         `#${this.id} .ptro-color-btn[data-id='${widgetState.target}']`).style['background-color'] =
         widgetState.alphaColor;
-      if (widgetState.palleteColor.substr(0, 1) !== '#') widgetState.palleteColor = `#${widgetState.palleteColor}`;
-      if (widgetState.target === 'line') {
-        setParam('activeColor', widgetState.palleteColor);
-        setParam('activeColorAlpha', widgetState.alpha);
-      } else if (widgetState.target === 'fill') {
-        setParam('activeFillColor', widgetState.palleteColor);
-        setParam('activeFillColorAlpha', widgetState.alpha);
-      } else if (widgetState.target === 'bg') {
-        setParam('backgroundFillColor', widgetState.palleteColor);
-        setParam('backgroundFillColorAlpha', widgetState.alpha);
-      } else if (widgetState.target === 'stroke') {
-        setParam('textStrokeColor', widgetState.palleteColor);
-        setParam('textStrokeColorAlpha', widgetState.alpha);
+      const palletRGB = HexToRGB(widgetState.palleteColor);
+      if (palletRGB !== undefined) {
+        widgetState.palleteColor = rgbToHex(palletRGB.r, palletRGB.g, palletRGB.b);
+        if (widgetState.target === 'line') {
+          setParam('activeColor', widgetState.palleteColor);
+          setParam('activeColorAlpha', widgetState.alpha);
+        } else if (widgetState.target === 'fill') {
+          setParam('activeFillColor', widgetState.palleteColor);
+          setParam('activeFillColorAlpha', widgetState.alpha);
+        } else if (widgetState.target === 'bg') {
+          setParam('backgroundFillColor', widgetState.palleteColor);
+          setParam('backgroundFillColorAlpha', widgetState.alpha);
+        } else if (widgetState.target === 'stroke') {
+          setParam('textStrokeColor', widgetState.palleteColor);
+          setParam('textStrokeColorAlpha', widgetState.alpha);
+        }
       }
     });
 


### PR DESCRIPTION
If you type in an invalid hex color (examples; ff0000, ;;;;) it will save that code and not allow you to reopen the color picker.  This PR will make it only update the stored color if it is valid.  It has a slightly less rigid validity requirement than before - ff0000 and #ff0000 will resolve to the same red.  